### PR TITLE
Fix dpdk bind error message.

### DIFF
--- a/sriov/sriov.go
+++ b/sriov/sriov.go
@@ -184,7 +184,11 @@ func enabledpdkmode(conf *dpdkConf, ifname string, dpdkmode bool) error {
 	cmd.Stdout = stdout
 	err := cmd.Run()
 	if err != nil {
-		return fmt.Errorf("DPDK binding failed with err msg %q:", stdout.String())
+		msg := stdout.String()
+		if msg == "" {
+			msg = err.Error()
+		}
+		return fmt.Errorf("DPDK binding failed with err msg: %q", msg)
 	}
 
 	stdout.Reset()


### PR DESCRIPTION
Previously problems with actually executing dpdk bind command were not logged. Add handling of shell-level error messages there. For example, if the `dpdk_tool` points to a non-existent file, a "no such file or directory" error is logged.