### PR TITLE
Adding support with VF device information

### DIFF
--- a/sriov/sriov.go
+++ b/sriov/sriov.go
@@ -651,6 +651,16 @@ func cmdDel(args *skel.CmdArgs) error {
 
 	netns, err := ns.GetNS(args.Netns)
 	if err != nil {
+		// according to:
+		// https://github.com/kubernetes/kubernetes/issues/43014#issuecomment-287164444
+		// if provided path does not exist (e.x. when node was restarted)
+		// plugin should silently return with success after releasing
+		// IPAM resources
+		_, ok := err.(ns.NSPathNotExistErr)
+		if ok {
+			return nil
+		}
+
 		return fmt.Errorf("failed to open netns %q: %v", netns, err)
 	}
 	defer netns.Close()


### PR DESCRIPTION
Previously SRIOV-CNI works in below mode:
    
    1. Given a PF info in conf file it will assign an available
       VF with all required information in hand
    
Since DeviceId is now allocated by SRIOV device plugin and
exposed via APIServer by kubelet, this commit adds another
mode for SRIOV-CNI to work together with SRIOV device plugin:
    
    2. It first trys to parse VF related DeviceId provided by meta
       plugin, then derive other DeviceInfo such as Pfname, VfId etc
       using this DeviceId. If all succeeds, it sets up the VF device
       with derived DeviceInfo, if fails, it falls back to use mode 1.