### PR TITLE
Fix crash when DeviceInfo is absent

### DIFF
--- a/sriov/sriov.go
+++ b/sriov/sriov.go
@@ -802,7 +802,8 @@ func cmdAdd(args *skel.CmdArgs) error {
 		args.IfName = n.IF0NAME
 	}
 
-	if n.DeviceInfo.PCIaddr != "" && n.DeviceInfo.Vfid >= 0 && n.DeviceInfo.Pfname != "" {
+
+	if n.DeviceInfo != nil && n.DeviceInfo.PCIaddr != "" && n.DeviceInfo.Vfid >= 0 && n.DeviceInfo.Pfname != "" {
 		if err = setupWithVfInfo(n, netns, args.ContainerID, args.IfName); err != nil {
 			return err
 		}


### PR DESCRIPTION
This commit: 9d79c1da1af720d42ebced44fe28ec29aa4642af introduced
code which relies on DeviceInfo in NetConf. That DeviceInfo should
be provided by meta plugin, but multus from dev/k8s-deviceid-model
branch doesn't provide Deviceinfo.
Also probably SRIOV CNI plugin can be alone in future when kubernetes will
fully conform CNI specification.

Signed-off-by: Alexey Perevalov <a.perevalov@samsung.com>