### PR TITLE
Run CNI daemonset container as privileged

### DIFF
--- a/images/sriov-cni-daemonset.yaml
+++ b/images/sriov-cni-daemonset.yaml
@@ -24,6 +24,8 @@ spec:
       containers:
       - name: kube-sriov-cni
         image: nfvpe/sriov-cni:latest
+        securityContext:
+          privileged: true
         resources:
           requests:
             cpu: "100m"


### PR DESCRIPTION
It needs write access to host /opt/cni/bin directory which is not generally
accessible to users.