### PR TITLE
Sharedvf config should be set only when the shared link device is found

### DIFF
--- a/sriov/sriov.go
+++ b/sriov/sriov.go
@@ -203,10 +203,9 @@ func releaseVF(conf *sriovtypes.NetConf, podifName string, cid string, netns ns.
 		//check for the shared vf net interface
 		ifName := podifName + "d1"
 		_, err := netlink.LinkByName(ifName)
-		if err != nil {
-			return fmt.Errorf("unable to get shared PF device: %v", err)
+		if err == nil {
+			conf.Sharedvf = true
 		}
-		conf.Sharedvf = true
 	}
 
 	for i := 1; i <= config.MaxSharedVf; i++ {


### PR DESCRIPTION
Shared VF links will be create during the VF setup procedure based
the number of devices found on '/sys/class/net/p3p1/device/virtfn4/net'
directory, and it will be renamed with the podIfName by adding a suffix
"d1". While releasing VFs, the check has to be corrected to see if there
are any shared VFs with "d1" suffix, before assumning Sharevf config.
Fixed the releaseVF, to ensure the Sharevf config is set correctly.

Fixes: https://github.com/intel/sriov-cni/issues/27