### PR TITLE
Initalize nLink to allocate the VF

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -169,3 +169,7 @@ func AssignFreeVF(conf *sriovtypes.NetConf) error {
 	}
 	return nil
 }
+
+func init() {
+	nLink = &MyNetlink{}
+}


### PR DESCRIPTION
While adding test cases for config package, the new variable
nLink is left uninitialized, resulting in cni crash. Initialize
the var to the appropriate struct to allocate VF successfully.