### PR TITLE
Support moveing VF which is eth0 on the host to the namespace

### DIFF
--- a/sriov/main.go
+++ b/sriov/main.go
@@ -89,6 +89,12 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return errors.New("IPAM plugin returned missing IPv4 config")
 	}
 
+	defer func() {
+		if err != nil {
+			ipam.ExecDel(n.IPAM.Type, args.StdinData)
+		}
+	}()
+
 	err = netns.Do(func(_ ns.NetNS) error {
 		return ipam.ConfigureIface(args.IfName, result)
 	})

--- a/sriov/main.go
+++ b/sriov/main.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"os"
 
 	"github.com/containernetworking/cni/pkg/ipam"
 	"github.com/containernetworking/cni/pkg/ns"
@@ -32,8 +33,11 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 	defer netns.Close()
 
+	old_ifname := os.Getenv("CNI_IFNAME")
+	defer os.Setenv("CNI_IFNAME", old_ifname)
 	if n.IF0NAME != "" {
 		args.IfName = n.IF0NAME
+		os.Setenv("CNI_IFNAME", args.IfName)
 	}
 
 	// Try assigning a VF from PF
@@ -112,8 +116,11 @@ func cmdDel(args *skel.CmdArgs) error {
 		return err
 	}
 
+	old_ifname := os.Getenv("CNI_IFNAME")
+	defer os.Setenv("CNI_IFNAME", old_ifname)
 	if n.IF0NAME != "" {
 		args.IfName = n.IF0NAME
+		os.Setenv("CNI_IFNAME", args.IfName)
 	}
 
 	// skip the IPAM release for the DPDK and L2 mode

--- a/sriov/main.go
+++ b/sriov/main.go
@@ -56,9 +56,19 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 
 	if n.DeviceInfo != nil && n.DeviceInfo.PCIaddr != "" && n.DeviceInfo.Vfid >= 0 && n.DeviceInfo.Pfname != "" {
-		if err = setupVF(n, args.IfName, args.ContainerID, netns); err != nil {
-			return fmt.Errorf("failed to set up pod interface %q from the device %q: %v", args.IfName, n.Master, err)
-		}
+		err = setupVF(n, args.IfName, args.ContainerID, netns)
+		defer func() {
+			if err != nil {
+				err = netns.Do(func(_ ns.NetNS) error {
+					_, err := netlink.LinkByName(args.IfName)
+					return err
+				})
+				if err == nil {
+					releaseVF(n, args.IfName, args.ContainerID, netns)
+				}
+			}
+		}()
+		
 	} else {
 		return fmt.Errorf("VF information are not available to invoke setupVF()")
 	}

--- a/sriov/sriov.go
+++ b/sriov/sriov.go
@@ -82,6 +82,11 @@ func moveIfToNetns(ifname string, netns ns.NetNS) error {
 		return fmt.Errorf("failed to lookup vf device %v: %q", ifname, err)
 	}
 
+	netlink.LinkSetDown(vfDev)
+	index := vfDev.Attrs().Index
+	vfName := fmt.Sprintf("dev%d", index)
+	renameLink(ifname, vfName)
+
 	if err = netlink.LinkSetUp(vfDev); err != nil {
 		return fmt.Errorf("failed to setup netlink device %v %q", ifname, err)
 	}


### PR DESCRIPTION
When using multus pluing the first interface will be eth0 and
the others will be netX. We need to make sure that before
we move VF which is eth0 to the container namespace it should
first be renamed to temp name before moving to the namespace.
This is to avoid conflict with the eth0 interface which already
exist in the namespace.