### PR TITLE
Support moveing VF which is eth0 on the host to the namespace

### DIFF
--- a/sriov/sriov.go
+++ b/sriov/sriov.go
@@ -82,6 +82,11 @@ func moveIfToNetns(ifname string, netns ns.NetNS) error {
 		return fmt.Errorf("failed to lookup vf device %v: %q", ifname, err)
 	}
 
+	netlink.LinkSetDown(vfDev)
+	index := vfDev.Attrs().Index
+	vfName := fmt.Sprintf("dev%d", index)
+	renameLink(ifname, vfName)
+
 	if err = netlink.LinkSetUp(vfDev); err != nil {
 		return fmt.Errorf("failed to setup netlink device %v %q", ifname, err)
 	}


### PR DESCRIPTION
When using multus pluing the first interface will be eth0 and
the others will be netX. We need to make sure that before
we move VF which is eth0 to the container namespace it should
first be renamed to temp name before moving to the namespace.
This is to avoid conflict with the eth0 interface which already
exist in the namespace.