### PR TITLE
Rename VF device name before moving to container namespace

### DIFF
--- a/sriov/sriov.go
+++ b/sriov/sriov.go
@@ -82,6 +82,15 @@ func moveIfToNetns(ifname string, netns ns.NetNS) error {
 		return fmt.Errorf("failed to lookup vf device %v: %q", ifname, err)
 	}
 
+	if err = netlink.LinkSetDown(vfDev); err != nil {
+		return fmt.Errorf("failed to down vf device %q: %v", ifname, err)
+	}
+	index := vfDev.Attrs().Index
+	vfName := fmt.Sprintf("dev%d", index)
+	if renameLink(ifname, vfName); err != nil {
+		return fmt.Errorf("failed to rename vf device %q to %q: %v", ifname, vfName, err)
+	}
+
 	if err = netlink.LinkSetUp(vfDev); err != nil {
 		return fmt.Errorf("failed to setup netlink device %v %q", ifname, err)
 	}


### PR DESCRIPTION
When using multus pluing the first interface will be eth0 and
    the others will be netX. We need to make sure that before
    we move VF which is eth0 to the container namespace it should
    first be renamed to temp name before moving to the namespace.
    This is to avoid conflict with the eth0 interface which already
    exist in the namespace.

    Fixes #40