### PR TITLE
Fixed docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,12 @@
-FROM centos:centos7
+FROM openshift/origin-release:golang-1.11 as builder
 
 # Add everything
 ADD . /usr/src/sriov-cni
 
-ENV INSTALL_PKGS "git golang"
-RUN yum install -y $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
-    cd /usr/src/sriov-cni && \
-    ./build && \
-    yum autoremove -y $INSTALL_PKGS && \
-    yum clean all && \
-    rm -rf /tmp/*
+RUN cd /usr/src/sriov-cni && make build
 
+FROM openshift/origin-base
+COPY --from=builder /usr/src/sriov-cni/build/sriov /usr/bin/
 WORKDIR /
 
 LABEL io.k8s.display-name="SR-IOV CNI"

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 
 # Set known directories.
 CNI_BIN_DIR="/host/opt/cni/bin"
-SRIOV_BIN_FILE="/usr/src/sriov-cni/bin/sriov"
+SRIOV_BIN_FILE="/usr/bin/sriov"
 
 # Give help text for parameters.
 function usage()


### PR DESCRIPTION
This patch changes Dockerfile to use multi-stage builds; specifically,
to use openshift builder and base images that already have golang,
make, git etc.; and to use 'make build' as part of the build process.