### PR TITLE
Remove IF0NAME from NetConf

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ options ixgbe max_vfs=8,8
 * `name` (string, required): the name of the network
 * `type` (string, required): "sriov"
 * `master` (string, required): name of the PF
-* `if0name` (string, optional): interface name in the Container
 * `l2enable` (boolean, optional): if `true` then add VF as L2 mode only, IPAM will not be executed
 * `vlan` (int, optional): VLAN ID to assign for the VF
 * `ipam` (dictionary, optional): IPAM configuration to be used for this network.
@@ -112,7 +111,6 @@ lo        Link encap:Local Loopback
     "name": "mynet",
     "type": "sriov",
     "master": "enp1s0f1",
-    "if0name": "net0",
     "dpdk": {
         "kernel_driver":"ixgbevf",
         "dpdk_driver":"igb_uio",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 
 	sriovtypes "github.com/intel/sriov-cni/pkg/types"
 	"github.com/intel/sriov-cni/pkg/utils"
@@ -56,13 +55,6 @@ func LoadConf(bytes []byte) (*sriovtypes.NetConf, error) {
 		return nil, fmt.Errorf("error: SRIOV-CNI loadConf: VF pci addr OR Master name is required")
 	}
 
-	if n.IF0NAME != "" {
-		valid := checkIf0name(n.IF0NAME)
-		if !valid {
-			return nil, fmt.Errorf(`"if0name" field should not be  equal to (eth0 | eth1 | lo | ""). It specifies the virtualized interface name in the pod`)
-		}
-	}
-
 	if n.CNIDir == "" {
 		n.CNIDir = defaultCNIDir
 	}
@@ -73,17 +65,6 @@ func LoadConf(bytes []byte) (*sriovtypes.NetConf, error) {
 	}
 
 	return n, nil
-}
-
-func checkIf0name(ifname string) bool {
-	op := []string{"eth0", "eth1", "lo", ""}
-	for _, if0name := range op {
-		if strings.Compare(if0name, ifname) == 0 {
-			return false
-		}
-	}
-
-	return true
 }
 
 func getVfInfo(vfPci string) (*sriovtypes.VfInformation, error) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -143,40 +143,6 @@ var _ = Describe("Config", func() {
 			_, err := LoadConf(conf)
 			Expect(err).Should(MatchError("error: SRIOV-CNI loadConf: VF pci addr OR Master name is required"))
 		})
-		It("Assuming incorrect config file - forbidden if0name", func() {
-			conf := []byte(`{
-        "name": "mynet",
-        "type": "sriov",
-	"if0name": "eth0",
-        "master": "enp175s0f1",
-        "mac":"66:77:88:99:aa:bb",
-        "vf": 0,
-        "ipam": {
-            "type": "host-local",
-            "subnet": "10.55.206.0/26",
-            "routes": [
-                { "dst": "0.0.0.0/0" }
-            ],
-            "gateway": "10.55.206.1"
-        }
-                        }`)
-			_, err := LoadConf(conf)
-			Expect(err).Should(MatchError("\"if0name\" field should not be  equal to (eth0 | eth1 | lo | \"\"). It specifies the virtualized interface name in the pod"))
-		})
-	})
-	Context("Checking checkIf0name function", func() {
-		It("Assuming correct interfaces", func() {
-			reservedIface := []string{"eth0", "eth1", "lo", ""}
-			for _, iface := range reservedIface {
-				Expect(checkIf0name(iface)).Should(BeFalse())
-			}
-		})
-		It("Assuming forbidden interfaces", func() {
-			forbiddenIface := []string{"eno0", "eth11", "!@#"}
-			for _, iface := range forbiddenIface {
-				Expect(checkIf0name(iface)).Should(BeTrue())
-			}
-		})
 	})
 	Context("Checking getVfInfo function", func() {
 		It("Assuming existing PF", func() {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -20,7 +20,6 @@ type NetConf struct {
 	DPDKConf   *dpdk.Conf     `json:"dpdk,omitempty"`
 	CNIDir     string         `json:"cniDir"`
 	Master     string         `json:"master"`
-	IF0NAME    string         `json:"if0name"`
 	L2Mode     bool           `json:"l2enable"`
 	Vlan       int            `json:"vlan"`
 	DeviceID   string         `json:"deviceID"`

--- a/sriov/main.go
+++ b/sriov/main.go
@@ -33,10 +33,6 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 	defer netns.Close()
 
-	if n.IF0NAME != "" {
-		args.IfName = n.IF0NAME
-	}
-
 	// Try assigning a VF from PF
 	if n.DeviceInfo == nil && n.Master != "" {
 		// Populate device info from PF
@@ -115,10 +111,6 @@ func cmdDel(args *skel.CmdArgs) error {
 	n, err := config.LoadConf(args.StdinData)
 	if err != nil {
 		return err
-	}
-
-	if n.IF0NAME != "" {
-		args.IfName = n.IF0NAME
 	}
 
 	// skip the IPAM release for the DPDK and L2 mode


### PR DESCRIPTION
Interface name is provided as args from the cni.
IF0NAME used in NetConf is not used and not required.

Signed-off-by: Saravanan KR <skramaja@redhat.com>
Fixes: #52 