### PR TITLE
update Dockerfile and add Dockerfile.rhel7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-FROM openshift/origin-release:golang-1.11 as builder
+FROM golang:alpine as builder
 
-# Add everything
 ADD . /usr/src/sriov-cni
 
+ENV HTTP_PROXY $http_proxy
+ENV HTTPS_PROXY $https_proxy
 RUN cd /usr/src/sriov-cni && make build
 
-FROM openshift/origin-base
+FROM alpine
 COPY --from=builder /usr/src/sriov-cni/build/sriov /usr/bin/
 WORKDIR /
 

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,0 +1,16 @@
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
+
+ADD . /usr/src/sriov-cni
+
+WORKDIR /usr/src/sriov-cni
+RUN ./build
+
+FROM registry.svc.ci.openshift.org/ocp/4.0:base
+COPY --from=builder /usr/src/sriov-cni/bin/sriov /usr/bin/
+WORKDIR /
+
+LABEL io.k8s.display-name="SR-IOV CNI"
+
+ADD ./images/entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This commit updates Dockerfile to use `alpine` instead of `openshift/origin-base` and adds Dockerfile.rhel7 for OpenShift build.