### PR TITLE
Restore original address of the VF; and support for delegates

### DIFF
--- a/cmd/sriov/main.go
+++ b/cmd/sriov/main.go
@@ -152,6 +152,9 @@ func cmdAdd(args *skel.CmdArgs) error {
 	} else {
 		result.IPs = []*current.IPConfig{{}}
 		result.IPs[0].Address = *ipAddr
+		ip := ipAddr.IP.Mask(ipAddr.Mask)
+		ip[3]++
+		result.IPs[0].Gateway = ip
 		result.IPs[0].Interface = current.Int(0)
 		result.IPs[0].Version = "4"
 	}

--- a/cmd/sriov/main.go
+++ b/cmd/sriov/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -164,13 +165,13 @@ func cmdAdd(args *skel.CmdArgs) error {
 		resultBytes, _ := json.Marshal(result)
 		rawPrevResult := make(map[string]interface{})
 		json.Unmarshal(resultBytes, &rawPrevResult)
-		netConf.RawPrevResult = &rawPrevResult
+		netConf.RawPrevResult = rawPrevResult
 		rawNetConf, err := json.Marshal(netConf)
 		if err != nil {
 			return fmt.Errorf("Error executing delegate. Could not marshal netConf with prevResult: %v", err)
 		}
 		for _, delegate := range netConf.Delegates {
-			r, err := invoke.DelegateAdd(delegate.Type, rawNetConf)
+			r, err := invoke.DelegateAdd(context.TODO(), delegate.Type, rawNetConf, nil)
 			if err != nil {
 				fmt.Errorf("error in executing delegate: %v. Result: %v. Netconf passed: (%v)", err, r, string(rawNetConf))
 			}

--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -175,14 +175,14 @@ func (s *sriovManager) SetupVF(conf *sriovtypes.NetConf, podifName string, cid s
 	if conf.MAC != "" {
 		hwaddr, err := net.ParseMAC(conf.MAC)
 		if err != nil {
-			return "", fmt.Errorf("failed to parse MAC address %s: %v", conf.MAC, err)
+			return nil, "", fmt.Errorf("failed to parse MAC address %s: %v", conf.MAC, err)
 		}
 
 		// Save the original effective MAC address before overriding it
 		conf.EffectiveMAC = linkObj.Attrs().HardwareAddr.String()
 
 		if err = s.nLink.LinkSetHardwareAddr(linkObj, hwaddr); err != nil {
-			return "", fmt.Errorf("failed to set netlink MAC address to %s: %v", hwaddr, err)
+			return nil, "", fmt.Errorf("failed to set netlink MAC address to %s: %v", hwaddr, err)
 		}
 	}
 

--- a/pkg/sriov/sriov_test.go
+++ b/pkg/sriov/sriov_test.go
@@ -345,7 +345,7 @@ var _ = Describe("Sriov", func() {
 			mocked.On("LinkSetVfVlan", mock.Anything, mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return(nil)
 			mocked.On("LinkSetVfVlanQos", mock.Anything, mock.AnythingOfType("int"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return(nil)
 			sm := sriovManager{nLink: mocked}
-			macAddr, err := sm.SetupVF(netconf, podifName, contID, targetNetNS)
+			_, macAddr, err := sm.SetupVF(netconf, podifName, contID, targetNetNS)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(macAddr).To(Equal("6e:16:06:0e:b7:e9"))
 		})

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"github.com/containernetworking/cni/pkg/types"
-	"github.com/containernetworking/cni/pkg/types/current"
 )
 
 // NetConf extends types.NetConf for sriov-cni

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types/current"
 )
 
 // NetConf extends types.NetConf for sriov-cni
@@ -16,13 +17,14 @@ type NetConf struct {
 	VlanQoS       int    `json:"vlanQoS"`
 	DeviceID      string `json:"deviceID"` // PCI address of a VF in valid sysfs format
 	VFID          int
-	HostIFNames   string // VF netdevice name(s)
-	ContIFNames   string // VF names after in the container; used during deletion
-	MinTxRate     *int   `json:"min_tx_rate"`          // Mbps, 0 = disable rate limiting
-	MaxTxRate     *int   `json:"max_tx_rate"`          // Mbps, 0 = disable rate limiting
-	SpoofChk      string `json:"spoofchk,omitempty"`   // on|off
-	Trust         string `json:"trust,omitempty"`      // on|off
-	LinkState     string `json:"link_state,omitempty"` // auto|enable|disable
+	HostIFNames   string          // VF netdevice name(s)
+	ContIFNames   string          // VF names after in the container; used during deletion
+	MinTxRate     *int            `json:"min_tx_rate"`          // Mbps, 0 = disable rate limiting
+	MaxTxRate     *int            `json:"max_tx_rate"`          // Mbps, 0 = disable rate limiting
+	SpoofChk      string          `json:"spoofchk,omitempty"`   // on|off
+	Trust         string          `json:"trust,omitempty"`      // on|off
+	LinkState     string          `json:"link_state,omitempty"` // auto|enable|disable
+	Delegates     []types.NetConf `json:"delegates"`
 	RuntimeConfig struct {
 		Mac string `json:"mac,omitempty"`
 	} `json:"runtimeConfig,omitempty"`


### PR DESCRIPTION
We have a case for using SRIOV where the IP addresses are pre-configured. If we remove the IPAM from the cni spec, all is well, but the address gets omitted when moving the interface to container namespace.
This PR stores the (v4) IP address, and puts it back on the interface after moving to the netns, but only if the IPAM was missing in the spec.

NB: IPv6 is not addressed here because assigning IPv6 address requires other sysctl flags to be enabled for netlink to succeed. One option is to try it and ignore upon privilege error. The other option is to not address it at all. This PR does not address IPv6 restore. Maybe a follow up PR can be done if needed.


**Edit** : Also added with the updated commit is support for 'delegates'. Delegates is just the same as what exists in Multus and can be used to execute downstream chain of plugins. In my particular use-case, I need to execute [sbr](https://github.com/containernetworking/plugins/tree/master/plugins/meta/sbr).
An example of how to specify delegates:
```apiVersion: "k8s.cni.cncf.io/v1"
kind: NetworkAttachmentDefinition
metadata:
  name: sriov-net1
  annotations:
    k8s.v1.cni.cncf.io/resourceName: intel.com/mlnx_sriov_rdma1
spec:
  config: '{
  "type": "sriov",
  "cniVersion": "0.3.1",
  "name": "sriov-network",
  "delegates": [
          {
                  "cniVersion": "0.3.1",
                  "type": "sbr",
                  "name": "sbr"
          }
  ]
}'
```
With the above example, I am able to invoke a subsequent CNI plugin and configure the routing on the pod.