### PR TITLE
config mistake in spec can cause run-time out of range error

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -154,6 +154,10 @@ func GetVFLinkNames(pciAddr string) (string, error) {
 		return "", fmt.Errorf("failed to read net dir of the device %s: %v", pciAddr, err)
 	}
 
+	if len(fInfos) == 0 {
+		return "", fmt.Errorf("VF device %s sysfs path (%s) has no entries", pciAddr, vfDir)
+	}
+
 	names = make([]string, 0)
 	for _, f := range fInfos {
 		names = append(names, f.Name())


### PR DESCRIPTION
this trivial change prevents cni from crashing if attempting to allocate a VF device that's already stood up in another pod