### PR TITLE
support CNI RuntimeConfig for Mac

### DIFF
--- a/cmd/sriov/main.go
+++ b/cmd/sriov/main.go
@@ -60,6 +60,13 @@ func cmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 
+	// RuntimeConfig takes preference than envArgs.
+	// This maintains compatibility of using envArgs
+	// for MAC config.
+	if netConf.RuntimeConfig.Mac != "" {
+		netConf.MAC = netConf.RuntimeConfig.Mac
+	}
+
 	netns, err := ns.GetNS(args.Netns)
 	if err != nil {
 		return fmt.Errorf("failed to open netns %q: %v", netns, err)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -7,19 +7,22 @@ import (
 // NetConf extends types.NetConf for sriov-cni
 type NetConf struct {
 	types.NetConf
-	DPDKMode     bool
-	Master       string
-	MAC          string
-	AdminMAC     string `json:"adminMAC"`
-	EffectiveMAC string `json:"effectiveMAC"`
-	Vlan         int    `json:"vlan"`
-	VlanQoS      int    `json:"vlanQoS"`
-	DeviceID     string `json:"deviceID"` // PCI address of a VF in valid sysfs format
-	VFID         int
-	HostIFNames  string // VF netdevice name(s)
-	ContIFNames  string // VF names after in the container; used during deletion
-	MaxTxRate    *int   `json:"max_tx_rate"`          // Mbps, 0 = disable rate limiting
-	SpoofChk     string `json:"spoofchk,omitempty"`   // on|off
-	Trust        string `json:"trust,omitempty"`      // on|off
-	LinkState    string `json:"link_state,omitempty"` // auto|enable|disable
+	DPDKMode      bool
+	Master        string
+	MAC           string
+	AdminMAC      string `json:"adminMAC"`
+	EffectiveMAC  string `json:"effectiveMAC"`
+	Vlan          int    `json:"vlan"`
+	VlanQoS       int    `json:"vlanQoS"`
+	DeviceID      string `json:"deviceID"` // PCI address of a VF in valid sysfs format
+	VFID          int
+	HostIFNames   string // VF netdevice name(s)
+	ContIFNames   string // VF names after in the container; used during deletion
+	MaxTxRate     *int   `json:"max_tx_rate"`          // Mbps, 0 = disable rate limiting
+	SpoofChk      string `json:"spoofchk,omitempty"`   // on|off
+	Trust         string `json:"trust,omitempty"`      // on|off
+	LinkState     string `json:"link_state,omitempty"` // auto|enable|disable
+	RuntimeConfig struct {
+		Mac string `json:"mac,omitempty"`
+	} `json:"runtimeConfig,omitempty"`
 }


### PR DESCRIPTION
CNI RuntimeConfig takes preference if configured,
envArgs can still be used for Mac configuration if
meta plugin(Multus) passes Mac as envArgs.

Fixes #104