### PR TITLE
Add support for min_tx_rate for SR-IOV VFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,12 +147,8 @@ echo 8 > /sys/class/net/enp2s0f0/device/sriov_numvfs
 * `link_state` (string, optional): enforce link state for the VF. Allowed values: auto, enable, disable. Note that driver support may differ for this feature. For example, `i40e` is known to work but `igb` doesn't.
 * `min_tx_rate` (int, optional): change the allowed minimum transmit bandwidth, in Mbps, for the VF. Setting this to 0 disables rate limiting. Note: Only supported on Mellanox NICs.
 * `max_tx_rate` (int, optional): change the allowed maximum transmit bandwidth, in Mbps, for the VF. 
-Setting this to 0 disables rate limiting.
+Setting this to 0 disables rate limiting. The min_tx_rate value should be <= max_tx_rate. Support of this feature depends on NICs and drivers.
 
-Note: min_tx_rate is only supported on Mellanox NICs. Setting the min_tx_rate on Intel NICs to any value other than 0 
-will prevent the Pod from being created with "Invalid Argument".
-
-The recommendation is to not configure min_tx_rate in the net-attach-defs for Intel NICs.
 
 ### Using DPDK drivers:
 If this plugin is used with a VF bound to a dpdk driver then the IPAM configuration will be ignored.

--- a/README.md
+++ b/README.md
@@ -145,10 +145,10 @@ echo 8 > /sys/class/net/enp2s0f0/device/sriov_numvfs
 * `spoofchk` (string, optional): turn packet spoof checking on or off for the VF
 * `trust` (string, optional): turn trust setting on or off for the VF
 * `link_state` (string, optional): enforce link state for the VF. Allowed values: auto, enable, disable. Note that driver support may differ for this feature. For example, `i40e` is known to work but `igb` doesn't.
-* `min_tx_rate` (int, optional): change the allowed minimum transmit bandwidth, in Mbps, for the VF. Setting this to 0 disables rate limiting. Note: Only supported on Mellanox NICs.
-* `max_tx_rate` (int, optional): change the allowed maximum transmit bandwidth, in Mbps, for the VF. 
-Setting this to 0 disables rate limiting. The min_tx_rate value should be <= max_tx_rate. Support of this feature depends on NICs and drivers.
+* `min_tx_rate` (int, optional): change the allowed minimum transmit bandwidth, in Mbps, for the VF. Setting this to 0 disables rate limiting. The min_tx_rate value should be <= max_tx_rate. Support of this feature depends on NICs and drivers.
 
+* `max_tx_rate` (int, optional): change the allowed maximum transmit bandwidth, in Mbps, for the VF. 
+Setting this to 0 disables rate limiting. 
 
 ### Using DPDK drivers:
 If this plugin is used with a VF bound to a dpdk driver then the IPAM configuration will be ignored.

--- a/README.md
+++ b/README.md
@@ -145,9 +145,14 @@ echo 8 > /sys/class/net/enp2s0f0/device/sriov_numvfs
 * `spoofchk` (string, optional): turn packet spoof checking on or off for the VF
 * `trust` (string, optional): turn trust setting on or off for the VF
 * `link_state` (string, optional): enforce link state for the VF. Allowed values: auto, enable, disable. Note that driver support may differ for this feature. For example, `i40e` is known to work but `igb` doesn't.
+* `min_tx_rate` (int, optional): change the allowed minimum transmit bandwidth, in Mbps, for the VF. Setting this to 0 disables rate limiting. Note: Only supported on Mellanox NICs.
 * `max_tx_rate` (int, optional): change the allowed maximum transmit bandwidth, in Mbps, for the VF. 
 Setting this to 0 disables rate limiting.
 
+Note: min_tx_rate is only supported on Mellanox NICs. Setting the min_tx_rate on Intel NICs to any value other than 0 
+will prevent the Pod from being created with "Invalid Argument".
+
+The recommendation is to not configure min_tx_rate in the net-attach-defs for Intel NICs.
 
 ### Using DPDK drivers:
 If this plugin is used with a VF bound to a dpdk driver then the IPAM configuration will be ignored.
@@ -226,7 +231,8 @@ EOF
     "type": "sriov",
     "deviceID": "0000:03:02.0",
     "vlan": 1000,
-    "max_tx_rate": 100,
+    "min_tx_rate": 100,
+    "max_tx_rate": 200,
     "spoofchk": "off",
     "trust": "on"
     "link_state": "enable"

--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -25,7 +25,7 @@ type NetlinkManager interface {
 	LinkSetDown(netlink.Link) error
 	LinkSetNsFd(netlink.Link, int) error
 	LinkSetName(netlink.Link, string) error
-	LinkSetVfTxRate(netlink.Link, int, int) error
+	LinkSetVfRate(netlink.Link, int, int, int) error
 	LinkSetVfSpoofchk(netlink.Link, int, bool) error
 	LinkSetVfTrust(netlink.Link, int, bool) error
 	LinkSetVfState(netlink.Link, int, uint32) error
@@ -81,9 +81,9 @@ func (n *MyNetlink) LinkSetName(link netlink.Link, name string) error {
 	return netlink.LinkSetName(link, name)
 }
 
-// LinkSetVfTxRate using NetlinkManager
-func (n *MyNetlink) LinkSetVfTxRate(link netlink.Link, vf int, rate int) error {
-	return netlink.LinkSetVfTxRate(link, vf, rate)
+// LinkSetVfRate using NetlinkManager
+func (n *MyNetlink) LinkSetVfRate(link netlink.Link, vf int, minRate int, maxRate int) error {
+	return netlink.LinkSetVfRate(link, vf, minRate, maxRate)
 }
 
 // LinkSetVfSpoofchk using NetlinkManager
@@ -311,10 +311,23 @@ func (s *sriovManager) ApplyVFConfig(conf *sriovtypes.NetConf) error {
 		}
 	}
 
-	// 3. Set link rate
+	// 3. Set min/max tx link rate. 0 means no rate limiting. min_tx_rate only supported on Mellanox NICs.
+	var minTxRate, maxTxRate int
+	rateConfigured := false
+	if conf.MinTxRate != nil {
+		minTxRate = *conf.MinTxRate
+		rateConfigured = true
+	}
+
 	if conf.MaxTxRate != nil {
-		if err = s.nLink.LinkSetVfTxRate(pfLink, conf.VFID, *conf.MaxTxRate); err != nil {
-			return fmt.Errorf("failed to set vf %d max_tx_rate to %d Mbps: %v", conf.VFID, conf.MaxTxRate, err)
+		maxTxRate = *conf.MaxTxRate
+		rateConfigured = true
+	}
+
+	if rateConfigured {
+		if err = s.nLink.LinkSetVfRate(pfLink, conf.VFID, minTxRate, maxTxRate); err != nil {
+			return fmt.Errorf("failed to set vf %d min_tx_rate to %d Mbps: max_tx_rate to %d Mbps: %v",
+				conf.VFID, minTxRate, maxTxRate, err)
 		}
 	}
 
@@ -403,7 +416,7 @@ func (s *sriovManager) ResetVFConfig(conf *sriovtypes.NetConf) error {
 	}
 
 	// Disable rate limiting
-	if err = s.nLink.LinkSetVfTxRate(pfLink, conf.VFID, 0); err != nil {
+	if err = s.nLink.LinkSetVfRate(pfLink, conf.VFID, 0, 0); err != nil {
 		return fmt.Errorf("failed to disable rate limiting for vf %d %v", conf.VFID, err)
 	}
 

--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -311,7 +311,7 @@ func (s *sriovManager) ApplyVFConfig(conf *sriovtypes.NetConf) error {
 		}
 	}
 
-	// 3. Set min/max tx link rate. 0 means no rate limiting. min_tx_rate only supported on Mellanox NICs.
+	// 3. Set min/max tx link rate. 0 means no rate limiting. Support depends on NICs and driver.
 	var minTxRate, maxTxRate int
 	rateConfigured := false
 	if conf.MinTxRate != nil {

--- a/pkg/sriov/sriov_test.go
+++ b/pkg/sriov/sriov_test.go
@@ -153,13 +153,13 @@ func (_m *MockNetlinkManager) LinkSetName(_a0 netlink.Link, _a1 string) error {
 	return r0
 }
 
-// LinkSetVfTxRate provides a mock function with given fields: _a0, _a1, _a2
-func (_m *MockNetlinkManager) LinkSetVfTxRate(_a0 netlink.Link, _a1 int, _a2 int) error {
-	ret := _m.Called(_a0, _a1, _a2)
+// LinkSetVfRate provides a mock function with given fields: _a0, _a1, _a2, _a3
+func (_m *MockNetlinkManager) LinkSetVfRate(_a0 netlink.Link, _a1 int, _a2 int, _a3 int) error {
+	ret := _m.Called(_a0, _a1, _a2, _a3)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(netlink.Link, int, int) error); ok {
-		r0 = rf(_a0, _a1, _a2)
+	if rf, ok := ret.Get(0).(func(netlink.Link, int, int, int) error); ok {
+		r0 = rf(_a0, _a1, _a2, _a3)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -18,6 +18,7 @@ type NetConf struct {
 	VFID          int
 	HostIFNames   string // VF netdevice name(s)
 	ContIFNames   string // VF names after in the container; used during deletion
+	MinTxRate     *int   `json:"min_tx_rate"`          // Mbps, 0 = disable rate limiting
 	MaxTxRate     *int   `json:"max_tx_rate"`          // Mbps, 0 = disable rate limiting
 	SpoofChk      string `json:"spoofchk,omitempty"`   // on|off
 	Trust         string `json:"trust,omitempty"`      // on|off


### PR DESCRIPTION
Add support for configuring the min_tx_rate when
configured in the net-attach-def.

Note: min_tx_rate is only supported on Mellanox NICs.

For Intel NICs, do not configure min_tx_rate in the
net-attach-def, or, set the value to 0. Any other
config will cause the pod to fail to be created,
"Invalid Argument" in logs.

Signed-off-by: vpickard <vpickard@redhat.com>