### PR TITLE
Change min/max_tx_rate json definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,9 @@ echo 8 > /sys/class/net/enp2s0f0/device/sriov_numvfs
 * `spoofchk` (string, optional): turn packet spoof checking on or off for the VF
 * `trust` (string, optional): turn trust setting on or off for the VF
 * `link_state` (string, optional): enforce link state for the VF. Allowed values: auto, enable, disable. Note that driver support may differ for this feature. For example, `i40e` is known to work but `igb` doesn't.
-* `min_tx_rate` (int, optional): change the allowed minimum transmit bandwidth, in Mbps, for the VF. Setting this to 0 disables rate limiting. The min_tx_rate value should be <= max_tx_rate. Support of this feature depends on NICs and drivers.
+* `minTxRate` (int, optional): change the allowed minimum transmit bandwidth, in Mbps, for the VF. Setting this to 0 disables rate limiting. The min_tx_rate value should be <= max_tx_rate. Support of this feature depends on NICs and drivers.
 
-* `max_tx_rate` (int, optional): change the allowed maximum transmit bandwidth, in Mbps, for the VF. 
+* `maxTxRate` (int, optional): change the allowed maximum transmit bandwidth, in Mbps, for the VF. 
 Setting this to 0 disables rate limiting. 
 
 ### Using DPDK drivers:

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -18,8 +18,8 @@ type NetConf struct {
 	VFID          int
 	HostIFNames   string // VF netdevice name(s)
 	ContIFNames   string // VF names after in the container; used during deletion
-	MinTxRate     *int   `json:"min_tx_rate"`          // Mbps, 0 = disable rate limiting
-	MaxTxRate     *int   `json:"max_tx_rate"`          // Mbps, 0 = disable rate limiting
+	MinTxRate     *int   `json:"minTxRate"`            // Mbps, 0 = disable rate limiting
+	MaxTxRate     *int   `json:"maxTxRate"`            // Mbps, 0 = disable rate limiting
 	SpoofChk      string `json:"spoofchk,omitempty"`   // on|off
 	Trust         string `json:"trust,omitempty"`      // on|off
 	LinkState     string `json:"link_state,omitempty"` // auto|enable|disable


### PR DESCRIPTION
SR-IOV Network Operator builds network attach defs
for SR-IOV CNI. With the current min_tx_rate and
max_tx_rate definitions, operator-sdk generate openapis
fails with name mismatch.

This patch will resolve that issue.

Signed-off-by: vpickard <vpickard@redhat.com>