### PR TITLE
changed temp naming format

### DIFF
--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -152,7 +152,7 @@ func (s *sriovManager) SetupVF(conf *sriovtypes.NetConf, podifName string, cid s
 	}
 
 	// tempName used as intermediary name to avoid name conflicts
-	tempName := fmt.Sprintf("%s%d", linkName, linkObj.Attrs().Index)
+	tempName := fmt.Sprintf("%s%d", "temp_", linkObj.Attrs().Index)
 
 	// 1. Set link down
 	if err := s.nLink.LinkSetDown(linkObj); err != nil {


### PR DESCRIPTION
Edited the format of the temp name to resolve #111 

Name format is now "temp_"+link index which is unique per node. 