### PR TITLE
Fix unused call result

### DIFF
--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -148,7 +148,7 @@ func (s *sriovManager) SetupVF(conf *sriovtypes.NetConf, podifName string, cid s
 
 	linkObj, err := s.nLink.LinkByName(linkName)
 	if err != nil {
-		fmt.Errorf("error getting VF netdevice with name %s", linkName)
+		return "", fmt.Errorf("error getting VF netdevice with name %s", linkName)
 	}
 
 	// tempName used as intermediary name to avoid name conflicts


### PR DESCRIPTION
During static code analysis done with Go Vet it was discovered that

- pkg/sriov/sriov.go:151:13: result of fmt.Errorf call not used


Code within this pull request fixes above issue.