### PR TITLE
Fix docker files after HadoLint check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,21 @@
 FROM golang:alpine as builder
 
-ADD . /usr/src/sriov-cni
+COPY . /usr/src/sriov-cni
 
 ENV HTTP_PROXY $http_proxy
 ENV HTTPS_PROXY $https_proxy
 
-RUN apk add --update --virtual build-dependencies build-base linux-headers && \
-    cd /usr/src/sriov-cni && \
+WORKDIR /usr/src/sriov-cni
+RUN apk add --no-cache --virtual build-dependencies build-base=~0.5 && \
     make clean && \
     make build
 
-FROM alpine
+FROM alpine:3
 COPY --from=builder /usr/src/sriov-cni/build/sriov /usr/bin/
 WORKDIR /
 
 LABEL io.k8s.display-name="SR-IOV CNI"
 
-ADD ./images/entrypoint.sh /
+COPY ./images/entrypoint.sh /
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,6 +1,6 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
 
-ADD . /usr/src/sriov-cni
+COPY . /usr/src/sriov-cni
 
 WORKDIR /usr/src/sriov-cni
 RUN make clean && \
@@ -12,6 +12,6 @@ WORKDIR /
 
 LABEL io.k8s.display-name="SR-IOV CNI"
 
-ADD ./images/entrypoint.sh /
+COPY ./images/entrypoint.sh /
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
During static code analysis done with HadoLint on DockerFiles several issues were discovered

- DL3003 Use WORKDIR to switch to a directory
- DL3018 Pin versions in apk add. Instead of apk add <package> use apk add <package>=<version>
- DL3019 Use the -no-cache switch to avoid the need to use -update and remove /var/cache/apk/* when done installing packages
- DL3006 Always tag the version of an image explicitly
- DL3020 Use COPY instead of ADD for files and folders

Code within this pull request fixes above issue.